### PR TITLE
Recreate club98 website structure and content

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  images: { unoptimized: true },
+  images: {
+    unoptimized: true,
+    domains: ['static.wixstatic.com']
+  },
   trailingSlash: true
 };
 

--- a/pages/datenschutz.tsx
+++ b/pages/datenschutz.tsx
@@ -1,0 +1,23 @@
+import Head from 'next/head';
+import styles from './static.module.css';
+
+export default function Datenschutz() {
+  return (
+    <>
+      <Head>
+        <title>Datenschutz – club98</title>
+        <meta name="description" content="Datenschutz des Club 98" />
+      </Head>
+      <main className={styles.main}>
+        <h1>Datenschutz</h1>
+        <p>
+          Gestützt auf Artikel 13 der schweizerischen Bundesverfassung und die datenschutzrechtlichen
+          Bestimmungen des Bundes (Datenschutzgesetz, DSG) hat jede Person Anspruch auf Schutz ihrer
+          Privatsphäre sowie auf Schutz vor Missbrauch ihrer persönlichen Daten. Wir halten diese
+          Bestimmungen ein. Persönliche Daten werden streng vertraulich behandelt und weder an Dritte
+          verkauft noch weitergegeben.
+        </p>
+      </main>
+    </>
+  );
+}

--- a/pages/impressum.tsx
+++ b/pages/impressum.tsx
@@ -1,0 +1,23 @@
+import Head from 'next/head';
+import styles from './static.module.css';
+
+export default function Impressum() {
+  return (
+    <>
+      <Head>
+        <title>Impressum – club98</title>
+        <meta name="description" content="Impressum des Club 98" />
+      </Head>
+      <main className={styles.main}>
+        <h1>Impressum</h1>
+        <p>Club 98, Joweidzentrum 4, 8630 Rüti</p>
+        <p>
+          <a href="mailto:pascale.pfister@club98.com">pascale.pfister@club98.com</a>
+        </p>
+        <p>
+          <a href="https://www.club98.ch">www.club98.ch</a>
+        </p>
+      </main>
+    </>
+  );
+}

--- a/pages/index.module.css
+++ b/pages/index.module.css
@@ -1,5 +1,87 @@
+.header {
+  background-color: #000;
+  color: #fff;
+}
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2rem;
+}
+.logo {
+  height: 60px;
+  width: auto;
+}
+.nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+.nav a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+}
 .main {
-  padding: 2rem;
   font-family: Arial, sans-serif;
+}
+.section {
+  padding: 4rem 2rem;
   text-align: center;
+}
+.membershipOptions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+.card {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  width: 200px;
+  background: #fafafa;
+}
+.account {
+  margin-top: 1rem;
+  font-weight: bold;
+}
+.gallery {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+.board {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  margin-bottom: 1rem;
+}
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 400px;
+  margin: 0 auto;
+}
+.form input,
+.form textarea {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+}
+.form button {
+  padding: 0.5rem;
+  background: #000;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+.footer {
+  text-align: center;
+  padding: 2rem;
+  background: #f2f2f2;
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,17 +1,145 @@
 import Head from 'next/head';
+import Image from 'next/image';
 import styles from './index.module.css';
 
 export default function Home() {
   return (
     <>
       <Head>
-        <title>club98 – Floorball Riders</title>
-        <meta name="description" content="Official landing page of club98, the exclusive member club of Floorball Riders." />
+        <title>club98 – Gönnervereinigung Floorball Riders</title>
+        <meta
+          name="description"
+          content="Offizielle Seite des Club 98, der Gönnervereinigung der Floorball Riders."
+        />
       </Head>
+      <header className={styles.header}>
+        <nav className={styles.nav}>
+          <Image
+            src="https://static.wixstatic.com/media/c8f628_0194a2ea47ed43fca9b275df1db48e28~mv2.png"
+            alt="club98 logo"
+            width={60}
+            height={60}
+            className={styles.logo}
+          />
+          <ul>
+            <li><a href="#mitgliedschaft">Mitgliedschaft</a></li>
+            <li><a href="#engagement">Engagement</a></li>
+            <li><a href="#ueber-uns">Über uns</a></li>
+            <li><a href="#kontakt">Kontakt</a></li>
+          </ul>
+        </nav>
+      </header>
       <main className={styles.main}>
-        <h1>Welcome to club98</h1>
-        <p>Exclusive community of Floorball Riders supporters.</p>
-        <p>Join us to support the team and enjoy member benefits.</p>
+        <section id="mitgliedschaft" className={styles.section}>
+          <h2>MITGLIEDSCHAFT</h2>
+          <div className={styles.membershipOptions}>
+            <div className={styles.card}>
+              <h3>Einzelperson / Ehepaar</h3>
+              <p>Fr. 333.00 / Fr. 555.00</p>
+            </div>
+            <div className={styles.card}>
+              <h3>Firma</h3>
+              <p>Fr. 999.00</p>
+            </div>
+            <div className={styles.card}>
+              <h3>Open</h3>
+              <p>ab Fr. 333.00</p>
+            </div>
+          </div>
+          <p className={styles.account}>
+            Vereinskonto Club 98<br />
+            IBAN CH92 8080 8002 2643 3181 9
+          </p>
+        </section>
+        <section id="engagement" className={styles.section}>
+          <h2>IHR ENGAGEMENT FÜR DEN LEISTUNGSSPORT</h2>
+          <p>
+            Ihre Mitgliedschaft ist ein soziales und gesellschaftliches Engagement für den
+            Leistungssport im Zürcher Oberland.
+          </p>
+          <div className={styles.gallery}>
+            <Image
+              src="https://static.wixstatic.com/media/c8f628_411a1c24548c47229841ab069d0cac67~mv2.jpg"
+              alt=""
+              width={200}
+              height={150}
+            />
+            <Image
+              src="https://static.wixstatic.com/media/c8f628_b282e15c6b9d4787b43986ff0f0517d7~mv2.jpg"
+              alt=""
+              width={200}
+              height={150}
+            />
+            <Image
+              src="https://static.wixstatic.com/media/c8f628_af427fcd52294b59ad80f67ecced04ea~mv2.jpg"
+              alt=""
+              width={200}
+              height={150}
+            />
+            <Image
+              src="https://static.wixstatic.com/media/c8f628_eb7d23634251477487e3b129819c090e~mv2.jpg"
+              alt=""
+              width={200}
+              height={150}
+            />
+            <Image
+              src="https://static.wixstatic.com/media/c8f628_49755cc050e84dd88398e50b9ffa3ada~mv2.jpg"
+              alt=""
+              width={200}
+              height={150}
+            />
+            <Image
+              src="https://static.wixstatic.com/media/c8f628_1640a183c81a471e848a5464dd0db8d2~mv2.jpg"
+              alt=""
+              width={200}
+              height={150}
+            />
+          </div>
+        </section>
+        <section id="ueber-uns" className={styles.section}>
+          <h2>ÜBER UNS</h2>
+          <p>
+            Der Club 98 ist ein Gönnerverein der Floorball Riders und unterstützt
+            Spitzenunihockey im Zürcher Oberland. Die Unterstützungsbeiträge werden
+            vollumfänglich in den Leistungssport der Floorball Riders investiert. Das primäre Ziel
+            und der Zweck der Gönnervereinigung soll die Förderung und Unterstützung des
+            Unihockeysports (Nachwuchs- und Leistungssport) der Floorball Riders sein.
+          </p>
+          <p>
+            Der Unihockeyverein Floorball Riders wurde 1998 durch den Zusammenschluss von
+            UHC Bubikon und UHC Dürnten gegründet. Seither spielt der Verein in den höchsten
+            Ligen des Schweizer Frauen-Unihockeys. Auch bei der Nachwuchsarbeit gehört der
+            Verein seit Jahren zu den besten 15 in der Schweiz.
+          </p>
+        </section>
+        <section id="kontakt" className={styles.section}>
+          <h2>KONTAKT</h2>
+          <h3>Der Vorstand CLUB 98</h3>
+          <div className={styles.board}>
+            <div>
+              <h4>Präsident</h4>
+              <p>Hans Altwegg</p>
+            </div>
+            <div>
+              <h4>Mitglied</h4>
+              <p>Pascale Pfister</p>
+            </div>
+          </div>
+          <form className={styles.form}>
+            <input type="text" placeholder="Vorname" />
+            <input type="text" placeholder="Nachname" />
+            <input type="email" placeholder="E-Mail-Adresse" />
+            <input type="text" placeholder="Betreff" />
+            <textarea placeholder="Nachricht" rows={4}></textarea>
+            <button type="submit">Absenden</button>
+          </form>
+        </section>
+        <footer className={styles.footer}>
+          <p>
+            <a href="/impressum">Impressum</a> | <a href="/datenschutz">Datenschutz</a>
+          </p>
+          <p>© 2022 CLUB98. Erstellt mit Wix.com</p>
+        </footer>
       </main>
     </>
   );

--- a/pages/static.module.css
+++ b/pages/static.module.css
@@ -1,0 +1,6 @@
+.main {
+  padding: 2rem;
+  font-family: Arial, sans-serif;
+  max-width: 800px;
+  margin: 0 auto;
+}


### PR DESCRIPTION
## Summary
- replicate club98.ch structure with sections for membership, engagement, about and contact
- add static pages for Impressum and Datenschutz
- include logo and gallery imagery with basic styling using remote assets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7fac94f1c8324845358436364a004