### PR TITLE
fix: configure base path for github pages

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,11 +1,15 @@
 /** @type {import('next').NextConfig} */
+const isProd = process.env.NODE_ENV === 'production';
+
 const nextConfig = {
   output: 'export',
   images: {
     unoptimized: true,
-    domains: ['static.wixstatic.com']
+    domains: ['static.wixstatic.com', 'meip.github.io'],
   },
-  trailingSlash: true
+  trailingSlash: true,
+  basePath: isProd ? '/club98.ch' : undefined,
+  assetPrefix: isProd ? '/club98.ch/' : undefined,
 };
 
 module.exports = nextConfig;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import Image from 'next/image';
+import Link from 'next/link';
 import styles from './index.module.css';
 
 export default function Home() {
@@ -136,7 +137,7 @@ export default function Home() {
         </section>
         <footer className={styles.footer}>
           <p>
-            <a href="/impressum">Impressum</a> | <a href="/datenschutz">Datenschutz</a>
+            <Link href="/impressum">Impressum</Link> | <Link href="/datenschutz">Datenschutz</Link>
           </p>
           <p>© 2022 CLUB98. Erstellt mit Wix.com</p>
         </footer>


### PR DESCRIPTION
## Summary
- set `basePath` and `assetPrefix` for production to serve assets under `/club98.ch`
- replace footer links with Next.js `Link` so internal pages work with the new base path
- allow loading images from GitHub Pages domain

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a7fffa3738832489a2605d75bc50b9