### PR TITLE
Adopt shared layout across site pages

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,57 @@
+import { ReactNode } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+
+type LayoutProps = {
+  children: ReactNode;
+};
+
+export default function Layout({ children }: LayoutProps) {
+  const { basePath } = useRouter();
+  return (
+    <>
+      <header className="bg-brand text-white sticky top-0 z-50">
+        <nav className="flex items-center justify-between max-w-6xl mx-auto p-4">
+          <Link href="/">
+            <Image
+              src={`${basePath}/logo_club98_weiss.png`}
+              alt="club98 logo"
+              width={60}
+              height={60}
+            />
+          </Link>
+          <ul className="flex gap-4 uppercase font-semibold">
+            <li>
+              <Link href="/#mitgliedschaft" className="hover:text-sky-400">
+                Mitgliedschaft
+              </Link>
+            </li>
+            <li>
+              <Link href="/#engagement" className="hover:text-sky-400">
+                Engagement
+              </Link>
+            </li>
+            <li>
+              <Link href="/#ueber-uns" className="hover:text-sky-400">
+                Über uns
+              </Link>
+            </li>
+            <li>
+              <Link href="/#kontakt" className="hover:text-sky-400">
+                Kontakt
+              </Link>
+            </li>
+          </ul>
+        </nav>
+      </header>
+      <main>{children}</main>
+      <footer className="text-center py-8 bg-brand text-white">
+        <p>
+          <Link href="/impressum">Impressum</Link> | <Link href="/datenschutz">Datenschutz</Link>
+        </p>
+        <p>© 2022 CLUB98.</p>
+      </footer>
+    </>
+  );
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,6 +1,13 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
+import { Barlow } from 'next/font/google';
+
+const barlow = Barlow({ subsets: ['latin'], weight: ['300', '400', '700'], variable: '--font-barlow' });
 
 export default function App({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />;
+  return (
+    <main className={`${barlow.variable} font-sans`}>
+      <Component {...pageProps} />
+    </main>
+  );
 }

--- a/pages/datenschutz.tsx
+++ b/pages/datenschutz.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Layout from '../components/Layout';
 
 export default function Datenschutz() {
   return (
@@ -7,16 +8,18 @@ export default function Datenschutz() {
         <title>Datenschutz – club98</title>
         <meta name="description" content="Datenschutz des Club 98" />
       </Head>
-      <main className="max-w-3xl mx-auto p-8 leading-7">
-        <h1 className="text-2xl font-bold mb-4">Datenschutz</h1>
-        <p>
-          Gestützt auf Artikel 13 der schweizerischen Bundesverfassung und die datenschutzrechtlichen
-          Bestimmungen des Bundes (Datenschutzgesetz, DSG) hat jede Person Anspruch auf Schutz ihrer
-          Privatsphäre sowie auf Schutz vor Missbrauch ihrer persönlichen Daten. Wir halten diese
-          Bestimmungen ein. Persönliche Daten werden streng vertraulich behandelt und weder an Dritte
-          verkauft noch weitergegeben.
-        </p>
-      </main>
+      <Layout>
+        <div className="max-w-3xl mx-auto p-8 leading-7">
+          <h1 className="text-2xl font-bold mb-4">Datenschutz</h1>
+          <p>
+            Gestützt auf Artikel 13 der schweizerischen Bundesverfassung und die datenschutzrechtlichen
+            Bestimmungen des Bundes (Datenschutzgesetz, DSG) hat jede Person Anspruch auf Schutz ihrer
+            Privatsphäre sowie auf Schutz vor Missbrauch ihrer persönlichen Daten. Wir halten diese
+            Bestimmungen ein. Persönliche Daten werden streng vertraulich behandelt und weder an Dritte
+            verkauft noch weitergegeben.
+          </p>
+        </div>
+      </Layout>
     </>
   );
 }

--- a/pages/impressum.tsx
+++ b/pages/impressum.tsx
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Layout from '../components/Layout';
 
 export default function Impressum() {
   return (
@@ -7,16 +8,18 @@ export default function Impressum() {
         <title>Impressum – club98</title>
         <meta name="description" content="Impressum des Club 98" />
       </Head>
-      <main className="max-w-3xl mx-auto p-8 leading-7">
-        <h1 className="text-2xl font-bold mb-4">Impressum</h1>
-        <p>Club 98, Joweidzentrum 4, 8630 Rüti</p>
-        <p>
-          <a href="mailto:pascale.pfister@club98.com">pascale.pfister@club98.com</a>
-        </p>
-        <p>
-          <a href="https://www.club98.ch">www.club98.ch</a>
-        </p>
-      </main>
+      <Layout>
+        <div className="max-w-3xl mx-auto p-8 leading-7">
+          <h1 className="text-2xl font-bold mb-4">Impressum</h1>
+          <p>Club 98, Joweidzentrum 4, 8630 Rüti</p>
+          <p>
+            <a href="mailto:pascale.pfister@club98.com">pascale.pfister@club98.com</a>
+          </p>
+          <p>
+            <a href="https://www.club98.ch">www.club98.ch</a>
+          </p>
+        </div>
+      </Layout>
     </>
   );
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from 'next/head';
 import Image from 'next/image';
-import Link from 'next/link';
 import { useRouter } from 'next/router';
+import Layout from '../components/Layout';
 
 export default function Home() {
   const { basePath } = useRouter();
@@ -14,24 +14,8 @@ export default function Home() {
           content="Offizielle Seite des Club 98, der Gönnervereinigung der Floorball Riders."
         />
       </Head>
-      <header className="bg-gray-800 text-white sticky top-0 z-50">
-        <nav className="flex items-center justify-between max-w-6xl mx-auto p-4">
-          <Image
-            src={`${basePath}/logo_club98_weiss.png`}
-            alt="club98 logo"
-            width={60}
-            height={60}
-          />
-          <ul className="flex gap-4 uppercase font-semibold">
-            <li><a href="#mitgliedschaft" className="hover:text-sky-400">Mitgliedschaft</a></li>
-            <li><a href="#engagement" className="hover:text-sky-400">Engagement</a></li>
-            <li><a href="#ueber-uns" className="hover:text-sky-400">Über uns</a></li>
-            <li><a href="#kontakt" className="hover:text-sky-400">Kontakt</a></li>
-          </ul>
-        </nav>
-      </header>
-      <main className="text-center">
-        <section className="relative flex items-center justify-center h-[60vh] text-white">
+      <Layout>
+        <section className="relative flex flex-col items-center justify-center h-[60vh] text-white text-center">
           <Image
             src={`${basePath}/play_01.jpg`}
             alt="Floorball Riders in action"
@@ -45,18 +29,18 @@ export default function Home() {
             <p className="text-lg">Gönnervereinigung Floorball Riders</p>
           </div>
         </section>
-        <section id="mitgliedschaft" className="py-16 px-4 max-w-5xl mx-auto">
+        <section id="mitgliedschaft" className="py-16 px-4 max-w-5xl mx-auto text-center">
           <h2 className="text-2xl font-bold mb-8">MITGLIEDSCHAFT</h2>
           <div className="flex flex-wrap justify-center gap-4">
-            <div className="border border-sky-600 p-4 w-48 bg-gray-800 text-white">
+            <div className="border border-sky-600 p-4 w-48 bg-brand text-white">
               <h3 className="font-semibold">Einzelperson / Ehepaar</h3>
               <p>Fr. 333.00 / Fr. 555.00</p>
             </div>
-            <div className="border border-sky-600 p-4 w-48 bg-gray-800 text-white">
+            <div className="border border-sky-600 p-4 w-48 bg-brand text-white">
               <h3 className="font-semibold">Firma</h3>
               <p>Fr. 999.00</p>
             </div>
-            <div className="border border-sky-600 p-4 w-48 bg-gray-800 text-white">
+            <div className="border border-sky-600 p-4 w-48 bg-brand text-white">
               <h3 className="font-semibold">Open</h3>
               <p>ab Fr. 333.00</p>
             </div>
@@ -109,13 +93,7 @@ export default function Home() {
             <button type="submit" className="p-2 bg-sky-700 text-white">Absenden</button>
           </form>
         </section>
-        <footer className="text-center py-8 bg-gray-800 text-white">
-          <p>
-            <Link href="/impressum">Impressum</Link> | <Link href="/datenschutz">Datenschutz</Link>
-          </p>
-          <p>© 2022 CLUB98.</p>
-        </footer>
-      </main>
+      </Layout>
     </>
   );
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -2,12 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
-@import url('https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;700&display=swap');
-
 html, body {
   padding: 0;
   margin: 0;
-  font-family: 'Barlow', sans-serif;
   background-color: #111820;
   color: #ffffff;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,11 +1,20 @@
 /** @type {import('tailwindcss').Config} */
+const defaultTheme = require('tailwindcss/defaultTheme');
+
 module.exports = {
   content: [
-    "./pages/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        brand: '#111820',
+      },
+      fontFamily: {
+        sans: ['var(--font-barlow)', ...defaultTheme.fontFamily.sans],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- use Next.js font loader to bring in Barlow and configure Tailwind for brand styles
- apply brand color to layout header/footer and membership cards
- remove global centering on home page for correct alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a99b10a968832496b17b90b00b2441